### PR TITLE
media_codecs : AOSP doesn't have ffmpeg config

### DIFF
--- a/audio/media_codecs.xml
+++ b/audio/media_codecs.xml
@@ -128,5 +128,4 @@
         </MediaCodec>
     </Decoders>
     <Include href="media_codecs_google_video.xml" />
-    <Include href="media_codecs_ffmpeg.xml" />
 </MediaCodecs>


### PR DESCRIPTION
Fixes the file not found error which caused the system to not load the config xml
